### PR TITLE
feat: add SDK version to user agent (release 1.5.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ```
 Language：PHP
 PHP version：7.1+
-Release ^1.5.1
+Release ^1.5.2
 Copyright：Ant financial services group
 ```
 

--- a/client/BaseAlipayClient.php
+++ b/client/BaseAlipayClient.php
@@ -86,6 +86,7 @@ abstract class BaseAlipayClient
         } else {
             $headers = $baseHeaders;
         }
+        $headers = $this->applySdkUserAgent($headers);
 
         $requestUrl = $this->genRequestUrl($path);
         $rsp = $this->sendRequest($requestUrl, $httpMethod, $headers, $reqBody);
@@ -117,7 +118,7 @@ abstract class BaseAlipayClient
         return $alipayRsp;
     }
 
-    private static $RESERVED_HEADERS = ["signature", "client-id", "request-time", "content-type", "agent-token"];
+    private static $RESERVED_HEADERS = ["signature", "client-id", "request-time", "content-type", "agent-token", "user-agent"];
     private static $SANDBOX_PRODUCTION_PATH_PREFIXES = [
         "/ams/api/v1/billing/",
         "/ams/api/v1/meter/",
@@ -174,6 +175,7 @@ abstract class BaseAlipayClient
                 $existingKeys[$lk] = true;
             }
         }
+        $headers = $this->applySdkUserAgent($headers);
 
         $requestUrl = $this->genRequestUrl($path);
         $rsp = $this->sendRequest($requestUrl, $httpMethod, $headers, $reqBody);
@@ -267,7 +269,7 @@ abstract class BaseAlipayClient
     {
         $baseHeader = array();
         $baseHeader[] = "Content-Type:application/json; charset=UTF-8";
-        $baseHeader[] = "User-Agent:global-alipay-sdk-php";
+        $baseHeader[] = "User-Agent:" . SdkVersion::userAgent();
         $baseHeader[] = "Request-Time:" . $requestTime;
         $baseHeader[] = "client-id:" . $clientId;
 
@@ -281,6 +283,20 @@ abstract class BaseAlipayClient
         $signatureHeader = "algorithm=RSA256,keyVersion=" . $keyVersion . ",signature=" . $signValue;
         $baseHeader[] = "Signature:" . $signatureHeader;
         return $baseHeader;
+    }
+
+    private function applySdkUserAgent($headers)
+    {
+        $result = array();
+        foreach ($headers as $header) {
+            $colonPos = strpos($header, ':');
+            if ($colonPos !== false && strtolower(substr($header, 0, $colonPos)) === 'user-agent') {
+                continue;
+            }
+            $result[] = $header;
+        }
+        $result[] = "User-Agent:" . SdkVersion::userAgent();
+        return $result;
     }
 
     private function genRequestUrl($path)

--- a/client/SdkVersion.php
+++ b/client/SdkVersion.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Client;
+
+final class SdkVersion
+{
+    public const VERSION = '1.5.2';
+
+    public static function userAgent()
+    {
+        return 'global-open-sdk-php/' . self::VERSION;
+    }
+}

--- a/init.php
+++ b/init.php
@@ -230,6 +230,7 @@ require __DIR__ . '/model/FundMoveDetail.php';
 
 
 //client
+require __DIR__ . '/client/SdkVersion.php';
 require __DIR__ . '/client/BaseAlipayClient.php';
 require __DIR__ . '/client/DefaultAlipayClient.php';
 require __DIR__ . '/client/SignatureTool.php';

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+set -eu
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <version>" >&2
+  exit 1
+fi
+
+VERSION=$1
+if ! printf '%s\n' "$VERSION" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
+  echo "Version must use stable SemVer format X.Y.Z: $VERSION" >&2
+  exit 1
+fi
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+
+python3 - "$ROOT_DIR" "$VERSION" <<'PY'
+import os
+import re
+import sys
+import tempfile
+
+root, version = sys.argv[1:3]
+
+
+def replace_once(relative_path, pattern, replacement):
+    path = os.path.join(root, relative_path)
+    with open(path, "r", encoding="utf-8", newline="") as source:
+        content = source.read()
+    updated, count = re.subn(pattern, replacement, content, count=1)
+    if count != 1:
+        raise SystemExit("Expected exactly one version field in {}".format(relative_path))
+    directory = os.path.dirname(path)
+    descriptor, temporary = tempfile.mkstemp(dir=directory)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="") as target:
+            target.write(updated)
+        os.chmod(temporary, os.stat(path).st_mode)
+        os.replace(temporary, path)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+replace_once(
+    "client/SdkVersion.php",
+    r"public const VERSION = '[^']+';",
+    "public const VERSION = '{}';".format(version),
+)
+replace_once(
+    "README.md",
+    r"(?m)^(?:Releass|Release) \^[^\r\n]+$",
+    "Release ^{}".format(version),
+)
+PY
+
+echo "Updated global-open-sdk-php to $VERSION"


### PR DESCRIPTION
## Summary
- Add unified SDK version identification via `User-Agent: global-open-sdk-php/{version}`
- Single version source: `client/SdkVersion.php::VERSION` (release tag must match it)
- Add `scripts/set-version.sh` as the unified version setter
- Bump version 1.5.1 → 1.5.2

Design doc: https://yuque.antfin.com/global-aquire/eibet3/ie54rtdm7fx24g6d