### PR TITLE
release: bump version to 1.5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ```
 Language：PHP
 PHP version：7.1+
-Release ^1.5.3
+Release ^1.5.4
 Copyright：Ant financial services group
 ```
 

--- a/client/SdkVersion.php
+++ b/client/SdkVersion.php
@@ -4,7 +4,7 @@ namespace Client;
 
 final class SdkVersion
 {
-    public const VERSION = '1.5.3';
+    public const VERSION = '1.5.4';
 
     public static function userAgent()
     {


### PR DESCRIPTION
## Summary
- bump PHP SDK version from 1.5.3 to 1.5.4
- update the release version in README

## Verification
- `composer validate --strict --no-check-publish`
- PHP syntax validation for 577 source files
- optimized Composer autoload generation
- verified User-Agent `global-open-sdk-php/1.5.4`