### PR TITLE
Update dispute notification fields

### DIFF
--- a/init.php
+++ b/init.php
@@ -218,6 +218,7 @@ require __DIR__ . '/model/DisputeEvidenceFormatType.php';
 require __DIR__ . '/model/Discount.php';
 require __DIR__ . '/model/DisputeJudgedResult.php';
 require __DIR__ . '/model/DisputeType.php';
+require __DIR__ . '/model/IssuerComments.php';
 require __DIR__ . '/model/PaymentMethodType.php';
 require __DIR__ . '/model/SubscriptionInfo.php';
 require __DIR__ . '/model/Declaration.php';

--- a/model/IssuerComments.php
+++ b/model/IssuerComments.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Model;
+
+class IssuerComments
+{
+    public $cardholderComments;
+    public $reasonOfInvalidAuthorization;
+    public $explanationOfCreditPresented;
+    public $judgeReason;
+
+    public function getCardholderComments()
+    {
+        return $this->cardholderComments;
+    }
+
+    public function setCardholderComments($cardholderComments)
+    {
+        $this->cardholderComments = $cardholderComments;
+    }
+
+    public function getReasonOfInvalidAuthorization()
+    {
+        return $this->reasonOfInvalidAuthorization;
+    }
+
+    public function setReasonOfInvalidAuthorization($reasonOfInvalidAuthorization)
+    {
+        $this->reasonOfInvalidAuthorization = $reasonOfInvalidAuthorization;
+    }
+
+    public function getExplanationOfCreditPresented()
+    {
+        return $this->explanationOfCreditPresented;
+    }
+
+    public function setExplanationOfCreditPresented($explanationOfCreditPresented)
+    {
+        $this->explanationOfCreditPresented = $explanationOfCreditPresented;
+    }
+
+    public function getJudgeReason()
+    {
+        return $this->judgeReason;
+    }
+
+    public function setJudgeReason($judgeReason)
+    {
+        $this->judgeReason = $judgeReason;
+    }
+}

--- a/request/notify/AlipayDisputeNotify.php
+++ b/request/notify/AlipayDisputeNotify.php
@@ -25,7 +25,30 @@ class AlipayDisputeNotify extends \Request\notify\AlipayNotify
 
     public $defendable;
 
+    public $captureId;
+
+    public $autoDefendReason;
+
     public $acquirerInfo;
+
+    /** @var \Model\IssuerComments|null */
+    public $issuerComments;
+
+    /**
+     * @return \Model\IssuerComments|null
+     */
+    public function getIssuerComments()
+    {
+        return $this->issuerComments;
+    }
+
+    /**
+     * @param \Model\IssuerComments|null $issuerComments
+     */
+    public function setIssuerComments($issuerComments)
+    {
+        $this->issuerComments = $issuerComments;
+    }
 
     /**
      * @return mixed
@@ -58,6 +81,38 @@ class AlipayDisputeNotify extends \Request\notify\AlipayNotify
     public function setDefendable($defendable)
     {
         $this->defendable = $defendable;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getCaptureId()
+    {
+        return $this->captureId;
+    }
+
+    /**
+     * @param mixed $captureId
+     */
+    public function setCaptureId($captureId)
+    {
+        $this->captureId = $captureId;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getAutoDefendReason()
+    {
+        return $this->autoDefendReason;
+    }
+
+    /**
+     * @param mixed $autoDefendReason
+     */
+    public function setAutoDefendReason($autoDefendReason)
+    {
+        $this->autoDefendReason = $autoDefendReason;
     }
 
 


### PR DESCRIPTION
## Summary
- add the IssuerComments notification model
- expose issuerComments on AlipayDisputeNotify
- add the documented captureId and autoDefendReason notification fields

## Validation
- PHP syntax checks
- Composer validation
- notification model smoke test