### PR TITLE
Fix PHP direct initialization

### DIFF
--- a/init.php
+++ b/init.php
@@ -1,5 +1,7 @@
 <?php
 
+require __DIR__ . '/model/ModelInterface.php';
+
 //request
 require __DIR__ . '/request/AlipayRequest.php';
 


### PR DESCRIPTION
## Summary
- load ModelInterface before request classes in init.php
- restore the documented non-Composer initialization path

## Validation
- PHP syntax check
- direct init.php loading smoke test
- Composer autoload smoke test
- Composer validation