### PR TITLE
chore(release): prepare PHP SDK 1.5.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ```
 Language：PHP
 PHP version：7.1+
-Release ^1.5.7
+Release ^1.5.8
 Copyright：Ant financial services group
 ```
 

--- a/client/SdkVersion.php
+++ b/client/SdkVersion.php
@@ -4,7 +4,7 @@ namespace Client;
 
 final class SdkVersion
 {
-    public const VERSION = '1.5.7';
+    public const VERSION = '1.5.8';
 
     public static function userAgent()
     {


### PR DESCRIPTION
## Summary
- Bump global-open-sdk-php from 1.5.7 to 1.5.8.
- Prepare the merged Payment Hold/Release API updates for publication.

## Validation
- Post-merge release regression: Offline 18/18 and Sandbox 5/5 passed.
- Composer strict validation passed.
- Full PHP syntax scan passed for 647 files.
- Optimized autoload, version, User-Agent, and case-collision checks passed.

## Scope
This PR changes only the SDK version source and README version example.